### PR TITLE
Update kontests.js

### DIFF
--- a/kontests.js
+++ b/kontests.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
   const urls = [
-    'https://www.kontests.net/api/v1/sites',
-    'https://www.kontests.net/api/v1/all'
+    'https://kontests.net/api/v1/sites',
+    'https://kontests.net/api/v1/all'
   ]
 
   Promise.all(urls.map(url =>


### PR DESCRIPTION
Removed 'www.' from url, because api doesn't work for "https://www.kontests.net/api/v1/all"  while it's working fine for 
"https://kontests.net/api/v1/all" 

You can paste url in search bar and try yourself.